### PR TITLE
Fix jax url

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ _Note:_ jax upgrade: cuda111 supports cuda 11.3 - https://github.com/google/jax/
 ``` bash
 pip install absl-py==0.13.0 biopython==1.79 chex==0.0.7 dm-haiku==0.0.4 dm-tree==0.1.6 immutabledict==2.0.0 jax==0.2.14 ml-collections==0.1.0 numpy==1.19.5 scipy==1.7.0 tensorflow==2.5.0 pandas==1.3.4 tensorflow-cpu==2.5.0
 
-pip install --upgrade jax==0.2.14 jaxlib==0.1.69+cuda111 -f https://storage.googleapis.com/jax-releases/jax_releases.html
+pip install --upgrade jax==0.2.14 jaxlib==0.1.69+cuda111 -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
 ```
 
 ### **Download alphafold release v2.2.0**


### PR DESCRIPTION
The releases URL for Cuda has changed, see https://github.com/e-bacho/dalle-mini/commit/a2f8bf0ecc9e97e7fb23c5e56f83916169093cf8

was giving an error